### PR TITLE
Corrected AESCipher._pad() by taking into account that semantics of …

### DIFF
--- a/pytuya/__init__.py
+++ b/pytuya/__init__.py
@@ -84,7 +84,8 @@ class AESCipher(object):
             plain_text += cipher.feed()  # flush final block
             return plain_text
     def _pad(self, s):
-        return s + (self.bs - len(s) % self.bs) * bytes(self.bs - len(s) % self.bs)
+        padnum = self.bs - len(s) % self.bs
+        return s + padnum * chr(padnum).encode()
     @staticmethod
     def _unpad(s):
         return s[:-ord(s[len(s)-1:])]


### PR DESCRIPTION
…bytes() changed from python 2 to 3

The padding was wrong in Python 3, because in Python 3 the bytes() function creates, if passed an integer, does not create the string representation for the integer but instead a byte array of the size passed as parameter.

in Python 2
`>>> bytes(5) # result: '5'`

in Python 3
`>>> bytes(5) # result: b'\x00\x00\x00\x00\x00'`