### PR TITLE
added support for tuya based bulbs

### DIFF
--- a/pytuya/__init__.py
+++ b/pytuya/__init__.py
@@ -297,6 +297,29 @@ class OutletDevice(XenonDevice):
 
         return data
 
+    def set_colour(self, rgb):
+        """
+        Set colour of an rgb bulb.
+
+        Args:
+            rgb(string): Value for the colour as hex.
+        """
+        payload = self.generate_payload(SET, {'5':'%s0000ffff'%(rgb), '2': 'colour'}) #FIXME / TODO We still need to figure out what the last 4 bytes of '5' do.
+        data = self._send_receive(payload)
+        return data
+
+    def set_white(self, brightness, colourtemp):
+        """
+        Set white coloured theme of an rgb bulb.
+
+        Args:
+            brightness(byte): Value for the brightness (25-255).
+            colourtemp(byte): Value for the colour temperature (0-255).
+        """
+        payload = self.generate_payload(SET, {'2':'white', '3':brightness, '4':colourtemp})
+        data = self._send_receive(payload)
+        return data
+
     def set_timer(self, num_secs):
         """
         Set a timer.

--- a/pytuya/__init__.py
+++ b/pytuya/__init__.py
@@ -121,6 +121,18 @@ payload_dict = {
     },
     "prefix": "000055aa00000000000000",    # Next byte is command byte ("hexByte") some zero padding, then length of remaining payload, i.e. command + suffix (unclear if multiple bytes used for length, zero padding implies could be more than one byte)
     "suffix": "000000000000aa55"
+  },
+  "bulb": {
+    "status": {
+      "hexByte": "0a",
+      "command": {"gwId": "", "devId": ""}
+    },
+    "set": {
+      "hexByte": "07",
+      "command": {"devId": "", "uid": "", "t": ""}
+    },
+    "prefix": "000055aa00000000000000",
+    "suffix": "000000000000aa55"
   }
 }
 
@@ -242,7 +254,6 @@ class XenonDevice(object):
         #print('full buffer(%d) %r' % (len(buffer), buffer))
         return buffer
 
-
 class OutletDevice(XenonDevice):
     def __init__(self, dev_id, address, local_key=None, dev_type=None):
         dev_type = dev_type or 'outlet'
@@ -297,29 +308,6 @@ class OutletDevice(XenonDevice):
 
         return data
 
-    def set_colour(self, rgb):
-        """
-        Set colour of an rgb bulb.
-
-        Args:
-            rgb(string): Value for the colour as hex.
-        """
-        payload = self.generate_payload(SET, {'5':'%s0000ffff'%(rgb), '2': 'colour'}) #FIXME / TODO We still need to figure out what the last 4 bytes of '5' do.
-        data = self._send_receive(payload)
-        return data
-
-    def set_white(self, brightness, colourtemp):
-        """
-        Set white coloured theme of an rgb bulb.
-
-        Args:
-            brightness(byte): Value for the brightness (25-255).
-            colourtemp(byte): Value for the colour temperature (0-255).
-        """
-        payload = self.generate_payload(SET, {'2':'white', '3':brightness, '4':colourtemp})
-        data = self._send_receive(payload)
-        return data
-
     def set_timer(self, num_secs):
         """
         Set a timer.
@@ -342,3 +330,80 @@ class OutletDevice(XenonDevice):
         log.debug('set_timer received data=%r', data)
         return data
 
+class BulbDevice(XenonDevice):
+    def __init__(self, dev_id, address, local_key=None, dev_type=None): #copied from outlet
+        dev_type = dev_type or 'bulb'
+        super(BulbDevice, self).__init__(dev_id, address, local_key, dev_type)
+
+    def status(self): #copied from outlet
+        log.debug('status() entry')
+        # open device, send request, then close connection
+        payload = self.generate_payload('status')
+
+        data = self._send_receive(payload)
+        log.debug('status received data=%r', data)
+
+        result = data[20:-8]  # hard coded offsets
+        log.debug('result=%r', result)
+        #result = data[data.find('{'):data.rfind('}')+1]  # naive marker search, hope neither { nor } occur in header/footer
+        #print('result %r' % result)
+        if result.startswith(b'{'):
+            # this is the regular expected code path
+            result = json.loads(result.decode())
+        elif result.startswith(PROTOCOL_VERSION_BYTES):
+            # got an encrypted payload, happens occasionally
+            # expect resulting json to look similar to:: {"devId":"ID","dps":{"1":true,"2":0},"t":EPOCH_SECS,"s":3_DIGIT_NUM}
+            # NOTE dps.2 may or may not be present
+            result = result[len(PROTOCOL_VERSION_BYTES):]  # remove version header
+            result = result[16:]  # remove (what I'm guessing, but not confirmed is) 16-bytes of MD5 hexdigest of payload
+            cipher = AESCipher(self.local_key)
+            result = cipher.decrypt(result)
+            log.debug('decrypted result=%r', result)
+            result = json.loads(result.decode())
+        else:
+            log.error('Unexpected status() payload=%r', result)
+
+        return result
+    
+    def set_status(self, on): #copied from outlet
+        """
+        Set status of the device to 'on' or 'off'.
+
+        Args:
+            on(bool):  True for 'on', False for 'off'.
+        """
+        payload = self.generate_payload(SET, {'1':on})
+        
+        data = self._send_receive(payload)
+        log.debug('set_status received data=%r', data)
+
+        return data
+    
+    def set_colour(self, rgb):
+        """
+        Set colour of an rgb bulb.
+
+        Args:
+            rgb(string): Value for the colour as hex.
+        """
+        payload = self.generate_payload(SET, {'5':'%s0000ffff'%(rgb), '2': 'colour'}) #FIXME / TODO We still need to figure out what the last 4 bytes of '5' do.
+        data = self._send_receive(payload)
+        return data
+
+    def set_white(self, brightness, colourtemp):
+        """
+        Set white coloured theme of an rgb bulb.
+
+        Args:
+            brightness(int): Value for the brightness (25-255).
+            colourtemp(int): Value for the colour temperature (0-255).
+        """
+        if isinstance(brightness, int):
+            brightness = str(brightness)
+        
+        if isinstance(colourtemp, int):
+            colourtemp = str(colourtemp)
+            
+        payload = self.generate_payload(SET, {'2':'white', '3':brightness, '4':colourtemp})
+        data = self._send_receive(payload)
+        return data

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(name='python-tuya',
 	description='Python implementation of the Tuya protocol',
 	author='clach04',
 	url='https://github.com/clach04/python-tuya',
-	packages=['pycrypto'],
+	install_requires=['pycrypto >= 2.6'],
 	)

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ from distutils.core import setup
 
 setup(name='python-tuya',
 	version='0.1',
+        packages=['pytuya'],
 	description='Python implementation of the Tuya protocol',
 	author='clach04',
 	url='https://github.com/clach04/python-tuya',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='python-tuya',
+	version='0.1',
+	description='Python implementation of the Tuya protocol',
+	author='clach04',
+	url='https://github.com/clach04/python-tuya',
+	packages=['pycrypto'],
+	)

--- a/tests.py
+++ b/tests.py
@@ -94,6 +94,32 @@ def mock_send_receive_status(data):
     ret = ret.encode(mock_byte_encoding)
     return ret
 
+def mock_send_receive_set_colour(data):
+    expected = '{"dps":{"2":"colour", "5":"ffffff0000ffff"}, "devId":"DEVICE_ID_HERE","uid":"DEVICE_ID_HERE", "t":"1516117564"}'
+    json_data, frame_ok = check_data_frame(data, "000055aa0000000000000007000000")
+
+    if frame_ok and compare_json_strings(json_data, expected, ['t']):
+        ret = '{"test_result":"SUCCESS"}'
+    else:
+        logging.error("json data not the same: {} != {}".format(json_data, expected))
+        ret = '{"test_result":"FAIL"}'
+
+    ret = ret.encode(mock_byte_encoding)
+    return ret
+
+def mock_send_receive_set_white(data):
+    expected = '{"dps":{"2":"white", "3":"255", "4":"255"}, "devId":"DEVICE_ID_HERE","uid":"DEVICE_ID_HERE", "t":"1516117564"}'
+    json_data, frame_ok = check_data_frame(data, "000055aa0000000000000007000000")
+
+    if frame_ok and compare_json_strings(json_data, expected, ['t']):
+        ret = '{"test_result":"SUCCESS"}'
+    else:
+        logging.error("json data not the same: {} != {}".format(json_data, expected))
+        ret = '{"test_result":"FAIL"}'
+
+    ret = ret.encode(mock_byte_encoding)
+    return ret
+
 class TestXenonDevice(unittest.TestCase):
     def test_set_timer(self):
         d = pytuya.OutletDevice('DEVICE_ID_HERE', 'IP_ADDRESS_HERE', LOCAL_KEY)
@@ -127,6 +153,26 @@ class TestXenonDevice(unittest.TestCase):
         result = d.status()
 
         # Make sure mock_send_receive_set_timer() has been called twice with correct parameters
+        self.assertEqual(result['test_result'], "SUCCESS")
+        
+    def test_set_colour(self):
+        d = pytuya.BulbDevice('DEVICE_ID_HERE', 'IP_ADDRESS_HERE', LOCAL_KEY)
+        d._send_receive = MagicMock(side_effect=mock_send_receive_set_colour)
+        
+        result = d.set_colour("ffffff")
+        result = result.decode(mock_byte_encoding)
+        result = json.loads(result)
+        
+        self.assertEqual(result['test_result'], "SUCCESS")
+        
+    def test_set_white(self):
+        d = pytuya.BulbDevice('DEVICE_ID_HERE', 'IP_ADDRESS_HERE', LOCAL_KEY)
+        d._send_receive = MagicMock(side_effect=mock_send_receive_set_white)
+        
+        result = d.set_white(255, 255)
+        result = result.decode(mock_byte_encoding)
+        result = json.loads(result)
+        
         self.assertEqual(result['test_result'], "SUCCESS")
 
 if __name__ == '__main__':


### PR DESCRIPTION
I looked at the communication between the bulb and the Tuya Smart Life app and I was able to understand some of the values that were being transmitted. There are two modes (colour mode and white mode). If your're in colour mode the values for brightness and colour temperature are being ignored. To change them in colour mode you have to calculate the new rgb values (e.g. convert it to hsv and add the brightness to V). There are still a couple of bytes left which don't make any sense to me - changing them didn't change the colour or the temperature or anything else. Maybe someone can take a look at those...