### PR TITLE
partial dps decode removed

### DIFF
--- a/pytuya/__init__.py
+++ b/pytuya/__init__.py
@@ -268,18 +268,18 @@ class Device(XenonDevice):
             if not isinstance(result, str):
                 result = result.decode()
             result = json.loads(result)
-        elif result.startswith(PROTOCOL_VERSION_BYTES):
-            # got an encrypted payload, happens occasionally
-            # expect resulting json to look similar to:: {"devId":"ID","dps":{"1":true,"2":0},"t":EPOCH_SECS,"s":3_DIGIT_NUM}
-            # NOTE dps.2 may or may not be present
-            result = result[len(PROTOCOL_VERSION_BYTES):]  # remove version header
-            result = result[16:]  # remove (what I'm guessing, but not confirmed is) 16-bytes of MD5 hexdigest of payload
-            cipher = AESCipher(self.local_key)
-            result = cipher.decrypt(result)
-            log.debug('decrypted result=%r', result)
-            if not isinstance(result, str):
-                result = result.decode()
-            result = json.loads(result)
+        #elif result.startswith(PROTOCOL_VERSION_BYTES):
+        #    # got an encrypted payload, happens occasionally
+        #    # expect resulting json to look similar to:: {"devId":"ID","dps":{"1":true,"2":0},"t":EPOCH_SECS,"s":3_DIGIT_NUM}
+        #    # NOTE dps.2 may or may not be present
+        #    result = result[len(PROTOCOL_VERSION_BYTES):]  # remove version header
+        #    result = result[16:]  # remove (what I'm guessing, but not confirmed is) 16-bytes of MD5 hexdigest of payload
+        #    cipher = AESCipher(self.local_key)
+        #    result = cipher.decrypt(result)
+        #    log.debug('decrypted result=%r', result)
+        #    if not isinstance(result, str):
+        #        result = result.decode()
+        #    result = json.loads(result)
         else:
             log.error('Unexpected status() payload=%r', result)
 


### PR DESCRIPTION
In status function when the payload is encrypted, only a partial dps is present in the decrypted payload. This is a source of bug in case of multiplug or bulb. I just put comments for that part.