### PR TITLE
move version and author info outside __init__ to allow proper pip install

### DIFF
--- a/pytuya/__init__.py
+++ b/pytuya/__init__.py
@@ -27,16 +27,14 @@ except ImportError:
     Crypto = AES = None
     import pyaes  # https://github.com/ricmoo/pyaes
 
+from pytuya.const import __version__
 
-version_tuple = (7, 0, 6)
-version = version_string = __version__ = '%d.%d.%d' % version_tuple
-__author__ = 'clach04'
 
 log = logging.getLogger(__name__)
 #logging.basicConfig()  # TODO include function name/line numbers in log
 #log.setLevel(level=logging.DEBUG)  # Debug hack!
 
-log.info('%s version %s', __name__, version)
+log.info('%s version %s', __name__, __version__)
 log.info('Python %s on %s', sys.version, sys.platform)
 if Crypto is None:
     log.info('Using pyaes version %r', pyaes.VERSION)
@@ -74,7 +72,7 @@ class AESCipher(object):
             return base64.b64encode(crypted_text)
         else:
             return crypted_text
-            
+
     def decrypt(self, enc, use_base64=True):
         if use_base64:
             enc = base64.b64decode(enc)
@@ -139,7 +137,7 @@ class XenonDevice(object):
     def __init__(self, dev_id, address, local_key=None, dev_type=None, connection_timeout=10):
         """
         Represents a Tuya device.
-        
+
         Args:
             dev_id (str): The device id.
             address (str): The network address.
@@ -147,7 +145,7 @@ class XenonDevice(object):
             dev_type (str, optional): The device type.
                 It will be used as key for lookups in payload_dict.
                 Defaults to None.
-            
+
         Attributes:
             port (int): The port to connect to.
         """
@@ -167,7 +165,7 @@ class XenonDevice(object):
     def _send_receive(self, payload):
         """
         Send single buffer `payload` and receive a single buffer.
-        
+
         Args:
             payload(bytes): Data to send.
         """
@@ -252,8 +250,8 @@ class XenonDevice(object):
         #print('postfix_payload %r' % hex(len(postfix_payload)))
         assert len(postfix_payload) <= 0xff
         postfix_payload_hex_len = '%x' % len(postfix_payload)  # TODO this assumes a single byte 0-255 (0x00-0xff)
-        buffer = hex2bin( payload_dict[self.dev_type]['prefix'] + 
-                          payload_dict[self.dev_type][command]['hexByte'] + 
+        buffer = hex2bin( payload_dict[self.dev_type]['prefix'] +
+                          payload_dict[self.dev_type][command]['hexByte'] +
                           '000000' +
                           postfix_payload_hex_len ) + postfix_payload
 
@@ -268,11 +266,11 @@ class XenonDevice(object):
         #print(bin2hex(buffer, pretty=False))
         #print('full buffer(%d) %r' % (len(buffer), " ".join("{:02x}".format(ord(c)) for c in buffer)))
         return buffer
-    
+
 class Device(XenonDevice):
     def __init__(self, dev_id, address, local_key=None, dev_type=None):
         super(Device, self).__init__(dev_id, address, local_key, dev_type)
-    
+
     def status(self):
         log.debug('status() entry')
         # open device, send request, then close connection
@@ -302,7 +300,7 @@ class Device(XenonDevice):
             if not isinstance(result, str):
                 result = result.decode()
             result = json.loads(result)
-        elif self.version == 3.3: 
+        elif self.version == 3.3:
             cipher = AESCipher(self.local_key)
             result = cipher.decrypt(result, False)
             log.debug('decrypted result=%r', result)
@@ -317,7 +315,7 @@ class Device(XenonDevice):
     def set_status(self, on, switch=1):
         """
         Set status of the device to 'on' or 'off'.
-        
+
         Args:
             on(bool):  True for 'on', False for 'off'.
             switch(int): The switch to set
@@ -332,7 +330,7 @@ class Device(XenonDevice):
         log.debug('set_status received data=%r', data)
 
         return data
-    
+
     def set_value(self, index, value):
         """
         Set int value of any index.
@@ -347,11 +345,11 @@ class Device(XenonDevice):
 
         payload = self.generate_payload(SET, {
             index: value})
-        
+
         data = self._send_receive(payload)
-        
+
         return data
-    
+
     def turn_on(self, switch=1):
         """Turn the device on"""
         self.set_status(True, switch)
@@ -363,7 +361,7 @@ class Device(XenonDevice):
     def set_timer(self, num_secs):
         """
         Set a timer.
-        
+
         Args:
             num_secs(int): Number of seconds
         """
@@ -397,7 +395,7 @@ class BulbDevice(Device):
     DPS             = 'dps'
     DPS_MODE_COLOUR = 'colour'
     DPS_MODE_WHITE  = 'white'
-    
+
     DPS_2_STATE = {
                 '1':'is_on',
                 '2':'mode',
@@ -414,14 +412,14 @@ class BulbDevice(Device):
     def _rgb_to_hexvalue(r, g, b):
         """
         Convert an RGB value to the hex representation expected by tuya.
-        
+
         Index '5' (DPS_INDEX_COLOUR) is assumed to be in the format:
         rrggbb0hhhssvv
-        
+
         While r, g and b are just hexadecimal values of the corresponding
         Red, Green and Blue values, the h, s and v values (which are values
         between 0 and 1) are scaled to 360 (h) and 255 (s and v) respectively.
-        
+
         Args:
             r(int): Value for the colour red as int from 0-255.
             g(int): Value for the colour green as int from 0-255.
@@ -456,7 +454,7 @@ class BulbDevice(Device):
         """
         Converts the hexvalue used by tuya for colour representation into
         an RGB value.
-        
+
         Args:
             hexvalue(string): The hex representation generated by BulbDevice._rgb_to_hexvalue()
         """
@@ -471,7 +469,7 @@ class BulbDevice(Device):
         """
         Converts the hexvalue used by tuya for colour representation into
         an HSV value.
-        
+
         Args:
             hexvalue(string): The hex representation generated by BulbDevice._rgb_to_hexvalue()
         """

--- a/pytuya/const.py
+++ b/pytuya/const.py
@@ -1,0 +1,3 @@
+version_tuple = (7, 0, 6)
+version = __version__ = '%d.%d.%d' % version_tuple
+__author__ = 'clach04'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-import pytuya
+from pytuya.const import __author__, __version__
 
 
 if len(sys.argv) <= 1:
@@ -35,8 +35,8 @@ else:
 
 setup(
     name='pytuya',
-    author=pytuya.__author__,
-    version=pytuya.__version__,
+    author=__author__,
+    version=__version__,
     description='Python interface to ESP8266MOD WiFi smart devices from Shenzhen Xenon',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Hello,

I am using your awesome lib in a [Octoprint](https://octoprint.org/) plugin called [TuyaSmartplug](https://github.com/ziirish/OctoPrint-TuyaSmartplug).

However, I'm encountering an issue where I can't just `pip install pytuya`.
This is because the setup.py imports *pytuya.__init__* in order to retrieve the `__author__` and `__version__` but the *__init__* also imports `pyaes` which is not yet installed at the time I run `pip install`.

You'll find the corresponding bug report here: https://github.com/ziirish/OctoPrint-TuyaSmartplug/issues/6

This patch attempts to resolve this situation.